### PR TITLE
Add PAPI 2.11.0 logging support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group 'ch.andre601'
-version '1.3.0'
+version '1.3.1'
 
 repositories {
     mavenCentral()

--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ repositories {
 
 dependencies {
     compileOnly('org.spigotmc:spigot-api:1.17.1-R0.1-SNAPSHOT')
-    compileOnly('me.clip:placeholderapi:2.10.10')
+    compileOnly('me.clip:placeholderapi:2.11.1')
     compileOnly('org.jetbrains:annotations:22.0.0')
     
     implementation('com.udojava:EvalEx:2.6')

--- a/src/main/java/ch/andre601/mathexpansion/logging/LegacyLogger.java
+++ b/src/main/java/ch/andre601/mathexpansion/logging/LegacyLogger.java
@@ -1,0 +1,19 @@
+package ch.andre601.mathexpansion.logging;
+
+import me.clip.placeholderapi.PlaceholderAPIPlugin;
+
+import java.util.logging.Logger;
+
+public class LegacyLogger implements LoggerUtil{
+    
+    private final Logger logger;
+    
+    public LegacyLogger(){
+        this.logger = PlaceholderAPIPlugin.getInstance().getLogger();
+    }
+    
+    @Override
+    public void logWarning(String text){
+        logger.warning("[Math] " + text);
+    }
+}

--- a/src/main/java/ch/andre601/mathexpansion/logging/LoggerUtil.java
+++ b/src/main/java/ch/andre601/mathexpansion/logging/LoggerUtil.java
@@ -1,0 +1,5 @@
+package ch.andre601.mathexpansion.logging;
+
+public interface LoggerUtil{
+    void logWarning(String text);
+}

--- a/src/main/java/ch/andre601/mathexpansion/logging/NativeLogger.java
+++ b/src/main/java/ch/andre601/mathexpansion/logging/NativeLogger.java
@@ -1,0 +1,17 @@
+package ch.andre601.mathexpansion.logging;
+
+import me.clip.placeholderapi.expansion.PlaceholderExpansion;
+
+public class NativeLogger implements LoggerUtil{
+    
+    private final PlaceholderExpansion expansion;
+    
+    public NativeLogger(PlaceholderExpansion expansion){
+        this.expansion = expansion;
+    }
+    
+    @Override
+    public void logWarning(String text){
+        expansion.warning(text);
+    }
+}


### PR DESCRIPTION
PlaceholderAPI 2.11.0 adds native logging support for PlaceholderExpansions, allowing the usage of `this.log` or one of the convenience methods such as `info` or `warn` to log messages in the console with a `[<expansion name>]` prefix.

To not break backwards compatibility, did I decide to make this setup to still support the old setup using the PAPI logger instance directly...