### PR TITLE
Try fixing broken numbers

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group 'ch.andre601'
-version '1.3.2'
+version '1.4.0'
 
 repositories {
     mavenCentral()

--- a/src/main/java/ch/andre601/mathexpansion/MathExpansion.java
+++ b/src/main/java/ch/andre601/mathexpansion/MathExpansion.java
@@ -11,7 +11,6 @@ import me.clip.placeholderapi.expansion.Configurable;
 import me.clip.placeholderapi.expansion.NMSVersion;
 import me.clip.placeholderapi.expansion.PlaceholderExpansion;
 import org.bukkit.OfflinePlayer;
-import org.bukkit.configuration.ConfigurationSection;
 import org.jetbrains.annotations.NotNull;
 
 import java.math.MathContext;

--- a/src/main/java/ch/andre601/mathexpansion/MathExpansion.java
+++ b/src/main/java/ch/andre601/mathexpansion/MathExpansion.java
@@ -33,7 +33,7 @@ public class MathExpansion extends PlaceholderExpansion implements Configurable 
     public MathExpansion(){
         this.logger = loadLogger();
         
-        defaults.put("Precision", 3);
+        defaults.put("Decimals", 3);
         defaults.put("Rounding", "half-up");
         defaults.put("Debug", false);
     }
@@ -58,6 +58,10 @@ public class MathExpansion extends PlaceholderExpansion implements Configurable 
 
     @Override
     public Map<String, Object> getDefaults(){
+        // Check if the old "Precision" setting is present and apply the old value to the new setting.
+        if(this.getInt("Precision", -1) >= 0)
+            this.defaults.put("Decimals", this.getInt("Precision", 3));
+        
         return this.defaults;
     }
     
@@ -96,12 +100,12 @@ public class MathExpansion extends PlaceholderExpansion implements Configurable 
         return evaluate(placeholder, values[1], precision, roundingMode);
     }
     
-    private String evaluate(String placeholder, String expression, int precision, RoundingMode roundingMode){
+    private String evaluate(String placeholder, String expression, int decimals, RoundingMode roundingMode){
         try{
             return new Expression(expression)
                 .setPrecision(128)
                 .eval()
-                .round(new MathContext(precision, roundingMode))
+                .round(new MathContext(decimals, roundingMode))
                 .toPlainString();
         }catch(Exception ex){
             // Math evaluation failed -> Invalid placeholder
@@ -151,7 +155,7 @@ public class MathExpansion extends PlaceholderExpansion implements Configurable 
     
     private int getPrecision(String value, String placeholder){
         if(isNullOrEmpty(value)){
-            return Math.max(this.getInt("Precision", 3), 0);
+            return Math.max(this.getInt("Decimals", 3), 0);
         }else{
             try{
                 return Integer.parseInt(value);

--- a/src/main/java/ch/andre601/mathexpansion/MathExpansion.java
+++ b/src/main/java/ch/andre601/mathexpansion/MathExpansion.java
@@ -11,6 +11,7 @@ import me.clip.placeholderapi.expansion.Configurable;
 import me.clip.placeholderapi.expansion.NMSVersion;
 import me.clip.placeholderapi.expansion.PlaceholderExpansion;
 import org.bukkit.OfflinePlayer;
+import org.bukkit.configuration.ConfigurationSection;
 import org.jetbrains.annotations.NotNull;
 
 import java.math.MathContext;
@@ -59,8 +60,14 @@ public class MathExpansion extends PlaceholderExpansion implements Configurable 
     @Override
     public Map<String, Object> getDefaults(){
         // Check if the old "Precision" setting is present and apply the old value to the new setting.
-        if(this.getInt("Precision", -1) >= 0)
+        if(this.getInt("Precision", -1) >= 0){
+            logger.info("Found old 'Precision' setting. Starting migration process...");
+            
             this.defaults.put("Decimals", this.getInt("Precision", 3));
+            this.defaults.put("Precision", null);
+            
+            logger.info("Migrated old settings. Please check the config.yml of PlaceholderAPI for problems.");
+        }
         
         return this.defaults;
     }
@@ -129,9 +136,9 @@ public class MathExpansion extends PlaceholderExpansion implements Configurable 
     // Method to print a placeholder warning every 10 seconds per placeholder.
     private void printPlaceholderWarning(String placeholder, String cause, Object... args){
         if(invalidPlaceholders.getIfPresent(placeholder) == null){
-            logger.logWarning("Invalid Placeholder detected!");
-            logger.logWarning("Placeholder: " + placeholder);
-            logger.logWarning(String.format("Cause: " + cause, args));
+            logger.warn("Invalid Placeholder detected!");
+            logger.warn("Placeholder: " + placeholder);
+            logger.warn(String.format("Cause: " + cause, args));
             
             invalidPlaceholders.put(placeholder, System.currentTimeMillis());
         }

--- a/src/main/java/ch/andre601/mathexpansion/logging/LegacyLogger.java
+++ b/src/main/java/ch/andre601/mathexpansion/logging/LegacyLogger.java
@@ -7,13 +7,19 @@ import java.util.logging.Logger;
 public class LegacyLogger implements LoggerUtil{
     
     private final Logger logger;
+    private final String prefix = "[Math] ";
     
     public LegacyLogger(){
         this.logger = PlaceholderAPIPlugin.getInstance().getLogger();
     }
     
     @Override
-    public void logWarning(String text){
-        logger.warning("[Math] " + text);
+    public void warn(String text){
+        logger.warning(prefix + text);
+    }
+    
+    @Override
+    public void info(String text){
+        logger.info(prefix + text);
     }
 }

--- a/src/main/java/ch/andre601/mathexpansion/logging/LoggerUtil.java
+++ b/src/main/java/ch/andre601/mathexpansion/logging/LoggerUtil.java
@@ -1,5 +1,7 @@
 package ch.andre601.mathexpansion.logging;
 
 public interface LoggerUtil{
-    void logWarning(String text);
+    void warn(String text);
+    
+    void info(String text);
 }

--- a/src/main/java/ch/andre601/mathexpansion/logging/NativeLogger.java
+++ b/src/main/java/ch/andre601/mathexpansion/logging/NativeLogger.java
@@ -11,7 +11,12 @@ public class NativeLogger implements LoggerUtil{
     }
     
     @Override
-    public void logWarning(String text){
+    public void warn(String text){
         expansion.warning(text);
+    }
+    
+    @Override
+    public void info(String text){
+        expansion.info(text);
     }
 }


### PR DESCRIPTION
Some numbers appear broken when using different sets of precision.

This PR makes the EvalEx use 128 digits by default and manually round with the provided precision and rounding mode.